### PR TITLE
Fix inconsistent text rendering

### DIFF
--- a/pages/api/download.js
+++ b/pages/api/download.js
@@ -18,7 +18,7 @@ export default function handler(req, res) {
             // });
 
             const browser = await chromium.puppeteer.launch({
-                args: [...chromium.args, "--hide-scrollbars", "--disable-web-security"],
+                args: [...chromium.args, "--hide-scrollbars", "--disable-web-security", "--font-render-hinting=none"],
                 defaultViewport: chromium.defaultViewport,
                 executablePath: await chromium.executablePath,
                 headless: true,


### PR DESCRIPTION
Font spacing in inconsistent when puppeteer is launched in headless mode ([related issue](https://github.com/puppeteer/puppeteer/issues/2410)).

For example, if you input the following text in wtfresume.com, the numbers are aligned as you can see in the screenshot.

```
aaaaa..................................................................|111
qwertyasdfzxcvyuiohjklbnm.............................|222
longlonglonglonglonglonglonglongshorty......|333
```

![image](https://user-images.githubusercontent.com/17952318/201054660-87a98878-ceea-49fb-a0b1-36e78dab39d0.png)

_____

However, this is what the rendered PDF looks like:

![image](https://user-images.githubusercontent.com/17952318/201056442-b660497e-310a-4c8f-b85b-0e394122e6ea.png)

- The numbers aren't aligned anymore
- The spacing between letters is very inconsistent

_____

With `--font-render-hinting=none`, the issue is fixed, as you can see here:

![image](https://user-images.githubusercontent.com/17952318/201056040-0437526c-aaf2-4b02-bcf4-39c2a2e52137.png)
